### PR TITLE
gups-hotset-move: Add option for whether or not to use HugeTLBFS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "duckdb"]
 	path = duckdb
 	url = https://github.com/duckdb/duckdb.git
+[submodule "YCSB"]
+	path = YCSB
+	url = https://github.com/brianfrankcooper/YCSB.git


### PR DESCRIPTION
The option is optional. If not used, it will use HugeTLBFS by default to maintain the current functionality.